### PR TITLE
Small  improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,18 +1,17 @@
 {
   "nodes": {
-    "mozillapkgs": {
-      "flake": false,
+    "flake-utils": {
       "locked": {
-        "lastModified": 1645464064,
-        "narHash": "sha256-YeN4bpPvHkVOpQzb8APTAfE7/R+MFMwJUMkqmfvytSk=",
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "rev": "15b7a05f20aab51c4ffbefddb1b448e862dccb7d",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -63,12 +62,47 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1637453606,
+        "narHash": "sha256-Gy6cwUswft9xqsjWxFYEnx/63/qzaFUwatcbV5GF/GQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8afc4e543663ca0a6a4f496262cd05233737e732",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "mozillapkgs": "mozillapkgs",
         "naersk": "naersk",
         "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay",
         "utils": "utils"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1649126009,
+        "narHash": "sha256-8htYkxrt4uHsxKKd9vqu31mvbgwbTLmYnbxd48kiLx0=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "29e20f0957084684bfed2fc0efddc424754c9c0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "utils": {


### PR DESCRIPTION
Небольшие изменения, не особо меняющие происходящее:
1. `nativeBuildInputs` не нужны так как все есть в `stdenv`, нужно лишь указать путь до `libclang`
2. Кажется `oxalica/rust-overlay` чуть более удобна в использовании во флейках чем `mozilla/nixpkgs-mozilla`: версии те же самые, но обновление по обновлению flake.
3. Добавил комментарии как "должен" рабоать оверрайд для конкретного derivation. Почему то при установке в `fexample-deps-0.1.0` начинает `cargo build` в `fexample-0.1.0`, а при установке в  `fexample-0.1.0` - собирает в `fexample-deps-0.1.0`.